### PR TITLE
fix: update parser to process labels entered in Korean

### DIFF
--- a/pegjs/agens.pegjs
+++ b/pegjs/agens.pegjs
@@ -45,7 +45,7 @@ _Edge = label:Id "[" id:GraphId "]" "[" from:GraphId "," to:GraphId  "]" props:O
 
 _Path = "[" _Vertex "," _Edge "," _Vertex ("," _Edge "," _Vertex)* "]"  {  return mkPath(); }
 
-Id = ([_\$A-Za-z][_\$0-9A-Za-z]*) { return text(); }
+Id = ([_\$A-Za-zㄱ-ㅎ가-힣][_\$0-9A-Za-zㄱ-ㅎ가-힣]*) { return text(); }
 
 GraphId = graphid:Number { return num2GraphId(text());}
 

--- a/pegjs/agens.pegjs
+++ b/pegjs/agens.pegjs
@@ -45,7 +45,7 @@ _Edge = label:Id "[" id:GraphId "]" "[" from:GraphId "," to:GraphId  "]" props:O
 
 _Path = "[" _Vertex "," _Edge "," _Vertex ("," _Edge "," _Vertex)* "]"  {  return mkPath(); }
 
-Id = ([_\$A-Za-zㄱ-ㅎ가-힣][_\$0-9A-Za-zㄱ-ㅎ가-힣]*) { return text(); }
+Id = ([_\$D][_\$w]*) { return text(); }
 
 GraphId = graphid:Number { return num2GraphId(text());}
 

--- a/test/unit/edgeUnitTest.js
+++ b/test/unit/edgeUnitTest.js
@@ -6,6 +6,7 @@ const g = require('../../lib/graph.js');
 describe('EdgeUnitTest suite', function () {
 
     const edge = agens.parse('e[5.7][7.3,7.9]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Edge'});
+    const koreanEdge = agens.parse('한국어[11.1][7.3,7.9]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Edge'});
 
     it('Test Label', function (done) {
         assert.strictEqual(edge.label, 'e');
@@ -19,6 +20,11 @@ describe('EdgeUnitTest suite', function () {
 
     it('Test Start ID', function (done) {
         assert.deepStrictEqual(edge.start, new g.GraphId(7, 3));
+        done();
+    });
+
+    it('Test Start ID (for Korean characters label edge)', function (done) {
+        assert.deepStrictEqual(koreanEdge.start, new g.GraphId(7, 3));
         done();
     });
 

--- a/test/unit/vertexUnitTest.js
+++ b/test/unit/vertexUnitTest.js
@@ -6,6 +6,7 @@ const g = require('../../lib/graph.js');
 describe('VertexUnitTest suite', function () {
 
     const vertex = agens.parse('v[7.9]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Vertex'});
+    const koreanVertex = agens.parse('한국어[11.1]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Vertex'});
 
     it('Test Label', function (done) {
         assert.strictEqual(vertex.label, 'v');
@@ -16,6 +17,11 @@ describe('VertexUnitTest suite', function () {
         assert.deepStrictEqual(vertex.id, new g.GraphId(7, 9));
         done();
     });
+
+    it('Test Vetex ID (for Korean characters label node)', function (done) {
+        assert.deepStrictEqual(koreanVertex.id, new g.GraphId(11, 1));
+        done();
+    })
 
     it('Test Properties', function (done) {
         assert.strictEqual(vertex.props.s, '');


### PR DESCRIPTION
update agens.pegjs at Id paser
add  to step for korean text in vertex and edge unit test
